### PR TITLE
POC for Proxying all analytics traffic

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,137 @@
+/* eslint-env browser */
+
+// If you want to proxy all HTTP requests to completely hide all visitor information, this is a proof of concept how to do it.
+
+// Proxy code - NodeJS Express example:
+/*
+const bodyParser = require('body-parser')
+const request = require('request')
+const jsonParser = bodyParser.json({ type: ['json', 'text/plain'] })
+router.post('/hello', jsonParser, (req, res) => {
+  res.header("Cache-Control", "no-cache, no-store, must-revalidate");
+  res.header("Pragma", "no-cache");
+  res.header("Expires", 0);
+  res.sendStatus(200)
+  request.post('https://api.simpleanalytics.io/post',
+    { body: JSON.stringify(req.body),
+      headers: { "Content-Type": "text/plain; charset=UTF-8", "User-Agent": "SimpleAnalyticsProxy/1.0, NodeJS"}
+    },
+    function (err, response, body) {
+      if (!err && response.statusCode === 201) {
+        console.log(body);
+      } else {
+        err ? console.error(err) : console.error(response.body)
+      }
+    })
+})
+*/
+
+(function(window, hostname, path, cdn) {
+  if (!window) return;
+
+  // Set urls outside try block because they are needed in the catch block
+  var protocol = window.location.protocol + '//';
+  hostname = hostname ? hostname : window.location.hostname
+  var apiUrl = protocol + hostname + path;
+  var cdnUrl = cdn ? protocol + cdn : (apiUrl + '.js');
+  var con = window.console;
+
+  try {
+    var nav = window.navigator;
+    var loc = window.location;
+    var doc = window.document;
+    var userAgent = nav.userAgent;
+    var dis = window.dispatchEvent;
+    var lastSendUrl;
+    var notSending = 'Not sending requests ';
+
+    var script = doc.querySelector('script[src="' + cdnUrl + '"]');
+    var mode = script ? script.getAttribute('data-mode') : null;
+
+    // A simple log function so the user knows why a request is not being send
+    var warn = function(message) {
+      if (con && con.warn) con.warn('Simple Analytics: ' + message);
+    }
+
+    // We do advanced bot detection in our API, but this line filters already most bots
+    if (userAgent.search(/(bot|spider|crawl)/ig) > -1) return warn(notSending + 'because user agent is a robot');
+
+    var post = function(isPushState) {
+      // Obfuscate personal data in URL by dropping the search and hash
+      var url = loc.protocol + '//' + loc.hostname + loc.pathname;
+
+      // Add hash to url when script is put in to hash mode
+      if (mode === 'hash' && loc.hash) url += loc.hash.split('?')[0];
+
+      // Don't send the last URL again (this could happen when pushState is used to change the URL hash or search)
+      if (lastSendUrl === url) return;
+      lastSendUrl = url;
+
+      // Skip prerender requests
+      if ('visibilityState' in doc && doc.visibilityState === 'prerender') return warn(notSending + 'when prerender');
+
+      // Don't track when Do Not Track is set to true
+      if ('doNotTrack' in nav && nav.doNotTrack === '1') return warn(notSending + 'when doNotTrack is enabled');
+
+      // Don't track when localhost
+      if (loc.hostname === 'localhost' || loc.protocol === 'file:') return warn(notSending + 'from localhost');
+
+      // From the search we grab the utm_source and ref and save only that
+      var refMatches = loc.search.match(/[?&](utm_source|source|ref)=([^?&]+)/gi);
+      var refs = refMatches ? refMatches.map(function(m) { return m.split('=')[1] }) : [];
+
+      var data = { url: url };
+      if (userAgent) data.ua = userAgent;
+      if (refs && refs[0]) data.urlReferrer = refs[0];
+      if (doc.referrer && !isPushState) data.referrer = doc.referrer;
+      if (window.innerWidth) data.width = window.innerWidth;
+
+      try {
+        data.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+      } catch (error) {
+        // nothing
+      }
+
+      var request = new XMLHttpRequest();
+      request.open('POST', apiUrl, true);
+
+      // We use content type text/plain here because we don't want to send an
+      // pre-flight OPTIONS request
+      request.setRequestHeader('Content-Type', 'text/plain; charset=UTF-8');
+      request.send(JSON.stringify(data));
+    }
+
+    var his = window.history;
+    var hisPushState = his ? his.pushState : null;
+    if (hisPushState && Event && dis) {
+      var stateListener = function(type) {
+        var orig = his[type];
+        return function() {
+          var rv = orig.apply(this, arguments);
+          var event = new Event(type);
+          event.arguments = arguments;
+          dis(event);
+          return rv;
+        };
+      };
+      his.pushState = stateListener('pushState');
+      window.addEventListener('pushState', function() {
+        post(true);
+      });
+    }
+
+    // When in hash mode, we record a pageview based on the onhashchange function
+    if (mode === 'hash' && 'onhashchange' in window) {
+      window.onhashchange = function() {
+        post(true);
+      }
+    }
+
+    post();
+  } catch (e) {
+    if (con && con.error) con.error(e);
+    // var url = apiUrl + '.gif';
+    // if (e && e.message) url = url + '?error=' + encodeURIComponent(e.message);
+    // new Image().src = url;
+  }
+})(window, null, '/hello', null);


### PR DESCRIPTION
A proof of concept on how to allow your own server to proxy all requests towards SimpleAnalytics increasing the privacy of an already privacy friendly platform even more. #2
(Resulting in a similar to On-Premise solution, without all the downsides of having it On-Premise)

Disclaimer:
- Not sure about rate limiting of IPs (in this case the server IP) which might impact this POC
- Does not work with Simple Analytics Extension, but you could filter out your own IP on the server side.
- Not implemented the gif part. I assume this one is for fallback purposes anyway? But can easily be added by proxying that one too.
